### PR TITLE
Add highlight for java

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -171,6 +171,7 @@ module.exports = {
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
+      additionalLanguages: ['java'],
     },
     algolia: {
       apiKey: 'c352a8b2c857f45d2b70a21eae903f40',


### PR DESCRIPTION
Currently, the website does not support highlight for java code. Such as [this](https://shenyu.apache.org/docs/next/developer/custom-filter/#cors-support).

Refer to [docs of docusaurus](https://docusaurus.io/docs/markdown-features/code-blocks#supported-languages), we can turn it on.