### PR TITLE
Apache dubbo example doc for version 2.4.0 and 2.4.1

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.4.0/user-guide/dubbo-proxy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.4.0/user-guide/dubbo-proxy.md
@@ -119,6 +119,18 @@ description: Dubbo服务接入
 </dependency>
 ```
 
+并在你的客户端项目 application.yml 文件中配置：
+
+```yaml
+shenyu:
+  client:
+    registerType: 你的服务注册类型
+    serverLists: 你的服务注册地址
+    props:
+      contextPath: /你的contextPath
+      appName: 你的应用名字
+      port: dubbo 服务端口
+```
 
 如果是`spring`构建，引入以下依赖：
 
@@ -163,36 +175,17 @@ description: Dubbo服务接入
 </dependency>
 ```
 
+并在你的客户端项目 application.yml 文件中配置：
 
-如果是`spring`构建，引入以下依赖：
-
-
-```xml
-<dependency>
-   <groupId>org.apache.shenyu</groupId>
-   <artifactId>shenyu-client-apache-dubbo</artifactId>
-   <version>${shenyu.version}</version>
-</dependency>
-```
-
-并在你的 `bean` 定义的 `xml` 文件中新增如下 ：
-
-```xml
-  <bean id ="apacheDubboServiceBeanPostProcessor" class ="org.apache.shenyu.client.apache.dubbo.ApacheDubboServiceBeanPostProcessor">
-       <constructor-arg ref="shenyuRegisterCenterConfig"/>
-  </bean>
-
-  <bean id="shenyuRegisterCenterConfig" class="org.apache.shenyu.register.common.config.ShenyuRegisterCenterConfig">
-       <property name="registerType" value="http"/>
-       <property name="serverList" value="http://localhost:9095"/>
-       <property name="props">
-          <map>
-            <entry key="contextPath" value="/你的contextPath"/>
-            <entry key="appName" value="你的名字"/>
-            <entry key="ifFull" value="false"/>
-          </map>
-        </property>
-  </bean>
+```yaml
+shenyu:
+  client:
+    registerType: 你的服务注册类型
+    serverLists: 你的服务注册地址
+    props:
+      contextPath: /你的contextPath
+      appName: 你的应用名字
+      port: dubbo 服务端口
 ```
 
 ## dubbo 插件设置

--- a/i18n/zh/docusaurus-plugin-content-docs/version-2.4.1/user-guide/dubbo-proxy.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-2.4.1/user-guide/dubbo-proxy.md
@@ -119,6 +119,18 @@ description: Dubbo服务接入
 </dependency>
 ```
 
+并在你的客户端项目 application.yml 文件中配置：
+
+```yaml
+shenyu:
+  client:
+    registerType: 你的服务注册类型
+    serverLists: 你的服务注册地址
+    props:
+      contextPath: /你的contextPath
+      appName: 你的应用名字
+      port: dubbo 服务端口
+```
 
 如果是`spring`构建，引入以下依赖：
 
@@ -163,36 +175,17 @@ description: Dubbo服务接入
 </dependency>
 ```
 
+并在你的客户端项目 application.yml 文件中配置：
 
-如果是`spring`构建，引入以下依赖：
-
-
-```xml
-<dependency>
-   <groupId>org.apache.shenyu</groupId>
-   <artifactId>shenyu-client-apache-dubbo</artifactId>
-   <version>${shenyu.version}</version>
-</dependency>
-```
-
-并在你的 `bean` 定义的 `xml` 文件中新增如下 ：
-
-```xml
-  <bean id ="apacheDubboServiceBeanPostProcessor" class ="org.apache.shenyu.client.apache.dubbo.ApacheDubboServiceBeanPostProcessor">
-       <constructor-arg ref="shenyuRegisterCenterConfig"/>
-  </bean>
-
-  <bean id="shenyuRegisterCenterConfig" class="org.apache.shenyu.register.common.config.ShenyuRegisterCenterConfig">
-       <property name="registerType" value="http"/>
-       <property name="serverList" value="http://localhost:9095"/>
-       <property name="props">
-          <map>
-            <entry key="contextPath" value="/你的contextPath"/>
-            <entry key="appName" value="你的名字"/>
-            <entry key="ifFull" value="false"/>
-          </map>
-        </property>
-  </bean>
+```yaml
+shenyu:
+  client:
+    registerType: 你的服务注册类型
+    serverLists: 你的服务注册地址
+    props:
+      contextPath: /你的contextPath
+      appName: 你的应用名字
+      port: dubbo 服务端口
 ```
 
 ## dubbo 插件设置

--- a/versioned_docs/version-2.4.0/user-guide/dubbo-proxy.md
+++ b/versioned_docs/version-2.4.0/user-guide/dubbo-proxy.md
@@ -117,6 +117,19 @@ Dubbo integration with gateway, please refer to : [shenyu-examples-dubbo](https:
    </dependency>
    ```
 
+   Config this in your client project's application.yml file
+   
+   ```yaml
+   shenyu:
+     client:
+       registerType: your service registerType
+       serverLists: your service register serverLists
+       props:
+         contextPath: /your contextPath
+         appName: your appName
+         port: dubbo service port
+   ```
+
   * Spring
 
       Add these dependencies：
@@ -163,36 +176,17 @@ Dubbo integration with gateway, please refer to : [shenyu-examples-dubbo](https:
        </dependency>
        ```
 
-  * Spring
-
-      Add these dependencies:
-
-      ```xml
-         <dependency>
-             <groupId>org.apache.shenyu</groupId>
-             <artifactId>shenyu-client-apache-dubbo</artifactId>
-             <version>${shenyu.version}</version>
-          </dependency>
-       ```
-
-      Injecct these properties into your Spring beans XML file:
-
-      ```xml
-      <bean id ="apacheDubboServiceBeanPostProcessor" class ="org.apache.shenyu.client.apache.dubbo.ApacheDubboServiceBeanPostProcessor">
-         <constructor-arg  ref="shenyuRegisterCenterConfig"/>
-      </bean>
-  
-      <bean id="shenyuRegisterCenterConfig" class="org.apache.shenyu.register.common.config.ShenyuRegisterCenterConfig">
-         <property name="registerType" value="http"/>
-         <property name="serverList" value="http://localhost:9095"/>
-         <property name="props">
-              <map>
-                   <entry key="contextPath" value="/your contextPath"/>
-                   <entry key="appName" value="your name"/>
-                   <entry key="isFull" value="false"/>
-              </map>
-         </property>
-      </bean>
+      Config this in your client project's application.yml file
+      
+      ```yaml
+      shenyu:
+        client:
+          registerType: your service registerType
+          serverLists: your service register serverLists
+          props:
+            contextPath: /your contextPath
+            appName: your appName
+            port: dubbo service port
       ```
 
 ## Dubbo configuration

--- a/versioned_docs/version-2.4.1/user-guide/dubbo-proxy.md
+++ b/versioned_docs/version-2.4.1/user-guide/dubbo-proxy.md
@@ -109,13 +109,26 @@ Dubbo integration with gateway, please refer to : [shenyu-examples-dubbo](https:
 
       Add these dependencies:
 
-   ```xml
-   <dependency>
-        <groupId>org.apache.shenyu</groupId>
-        <artifactId>shenyu-spring-boot-starter-client-alibaba-dubbo</artifactId>
-        <version>${shenyu.version}</version>
-   </dependency>
-   ```
+      ```xml
+      <dependency>
+           <groupId>org.apache.shenyu</groupId>
+           <artifactId>shenyu-spring-boot-starter-client-alibaba-dubbo</artifactId>
+           <version>${shenyu.version}</version>
+      </dependency>
+      ```
+
+      Config this in your client project's application.yml file
+
+      ```yaml
+      shenyu:
+        client:
+          registerType: your service registerType
+          serverLists: your service register serverLists
+          props:
+            contextPath: /your contextPath
+            appName: your appName
+            port: dubbo service port
+      ```
 
   * Spring
 
@@ -163,36 +176,17 @@ Dubbo integration with gateway, please refer to : [shenyu-examples-dubbo](https:
        </dependency>
        ```
 
-  * Spring
+      Config this in your client project's application.yml file
 
-      Add these dependencies:
-
-      ```xml
-         <dependency>
-             <groupId>org.apache.shenyu</groupId>
-             <artifactId>shenyu-client-apache-dubbo</artifactId>
-             <version>${shenyu.version}</version>
-          </dependency>
-       ```
-
-      Injecct these properties into your Spring beans XML file:
-
-      ```xml
-      <bean id ="apacheDubboServiceBeanPostProcessor" class ="org.apache.shenyu.client.apache.dubbo.ApacheDubboServiceBeanPostProcessor">
-         <constructor-arg  ref="shenyuRegisterCenterConfig"/>
-      </bean>
-  
-      <bean id="shenyuRegisterCenterConfig" class="org.apache.shenyu.register.common.config.ShenyuRegisterCenterConfig">
-         <property name="registerType" value="http"/>
-         <property name="serverList" value="http://localhost:9095"/>
-         <property name="props">
-              <map>
-                   <entry key="contextPath" value="/your contextPath"/>
-                   <entry key="appName" value="your name"/>
-                   <entry key="isFull" value="false"/>
-              </map>
-         </property>
-      </bean>
+      ```yaml
+      shenyu:
+        client:
+          registerType: your service registerType
+          serverLists: your service register serverLists
+          props:
+            contextPath: /your contextPath
+            appName: your appName
+            port: dubbo service port
       ```
 
 ## Dubbo configuration


### PR DESCRIPTION
I download our tag 2.4.0 and tag 2.4.1 source code with the doc under user-guide/dubbo-proxy.md to test apache dubbo example. After test in my local, I delete the spring part and improved the spring-boot part doc.