### PR TITLE
[BUG] In the deployment document,the description of using Mysql to store data lack of 'mysql-connector.jar'

### DIFF
--- a/docs/deployment/deployment-docker.md
+++ b/docs/deployment/deployment-docker.md
@@ -20,7 +20,7 @@ This article introduces the use of `docker` to deploy the `Apache ShenYu` gatewa
 > docker run -d -p 9095:9095 --net shenyu apache/shenyu-admin:${current.version}
 ```
 
-* use `MySQL` to store data, copy `mysql-connector.jar` to `/$(your_work_dir)/ext-lib`：
+* use `MySQL` to store data, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to `/$(your_work_dir)/ext-lib`：
 
 ```
 docker run -v /${your_work_dir}/ext-lib:/opt/shenyu-admin/ext-lib -e "SPRING_PROFILES_ACTIVE=mysql" -e "spring.datasource.url=jdbc:mysql://${your_ip_port}/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false" -e "spring.datasource.username=${your_username}" -e "spring.datasource.password=${your_password}" -d -p 9095:9095 --net shenyu apache/shenyu-admin:${current.version}

--- a/docs/deployment/deployment-k8s.md
+++ b/docs/deployment/deployment-k8s.md
@@ -19,7 +19,7 @@ This article introduces the use of `k8s` to deploy the `Apache ShenYu` gateway.
 >
 > Similar to the h2 process, there are two points to note
 >
-> 1. you need to load mysql-connector.jar, so you need a place to store the file
+> 1. you need to load [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar), so you need a place to store the file
 > 2. you need to specify an external mysql database configuration to proxy the external mysql database via endpoint
 >
 > The process is as follows.

--- a/docs/deployment/deployment-local.md
+++ b/docs/deployment/deployment-local.md
@@ -28,7 +28,7 @@ This article introduces how to start the `Apache ShenYu` gateway in the local en
 
   * If you use `h2` to store, set the variable `--spring.profiles.active = h2`.
 
-  * If you use `MySQL` for storage, modify the `mysql` configuration in `application.yaml`.
+  * If you use `MySQL` for storage, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to /$(your_work_dir)/ext-lib, and modify the `mysql` configuration in `application.yaml`.
   
   * If you use `PostgreSql` for storage, modify the `pg` of `spring.profiles.active` configuration in `application.yaml`.
 

--- a/docs/deployment/deployment-package.md
+++ b/docs/deployment/deployment-package.md
@@ -22,7 +22,7 @@ This article introduces the deployment of the `Apache ShenYu` gateway using the 
 > linux: ./start.sh --spring.profiles.active = h2
 ```
 
-* use `MySQL` to store data, go to the `/conf` directory, and modify the configuration of `mysql` in `application.yaml`.
+* use `MySQL` to store data, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to /$(your_work_dir)/ext-lib, go to the `/conf` directory, and modify the configuration of `mysql` in `application.yaml`.
 
 ```
 > windows: start.bat 

--- a/versioned_docs/version-2.4.0/deployment/deployment-docker.md
+++ b/versioned_docs/version-2.4.0/deployment/deployment-docker.md
@@ -20,7 +20,7 @@ This article introduces the use of `docker` to deploy the `Apache ShenYu` gatewa
 > docker run -d -p 9095:9095 --net shenyu apache/shenyu-admin:2.4.0
 ```
 
-* use `MySQL` to store data, copy `mysql-connector.jar` to `/$(your_work_dir)/ext-lib`：
+* use `MySQL` to store data, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to `/$(your_work_dir)/ext-lib`：
 
 ```
 docker run -v /${your_work_dir}/ext-lib:/opt/shenyu-admin/ext-lib -e "SPRING_PROFILES_ACTIVE=mysql" -e "spring.datasource.url=jdbc:mysql://${your_ip_port}/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false" -e "spring.datasource.username=${your_username}" -e "spring.datasource.password=${your_password}" -d -p 9095:9095 --net shenyu apache/shenyu-admin:2.4.0

--- a/versioned_docs/version-2.4.0/deployment/deployment-k8s.md
+++ b/versioned_docs/version-2.4.0/deployment/deployment-k8s.md
@@ -19,7 +19,7 @@ This article introduces the use of `k8s` to deploy the `Apache ShenYu` gateway.
 >
 > Similar to the h2 process, there are two points to note
 >
-> 1. you need to load mysql-connector.jar, so you need a place to store the file
+> 1. you need to load [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar), so you need a place to store the file
 > 2. you need to specify an external mysql database configuration to proxy the external mysql database via endpoint
 >
 > The process is as follows.

--- a/versioned_docs/version-2.4.0/deployment/deployment-local.md
+++ b/versioned_docs/version-2.4.0/deployment/deployment-local.md
@@ -28,7 +28,7 @@ This article introduces how to start the `Apache ShenYu` gateway in the local en
 
   * If you use `h2` to store, set the variable `--spring.profiles.active = h2`.
 
-  * If you use `MySQL` for storage, modify the `mysql` configuration in `application.yaml`.
+* If you use `MySQL` for storage, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to /$(your_work_dir)/ext-lib, and modify the `mysql` configuration in `application.yaml`.
 
 * use the development tool to start `org.apache.shenyu.bootstrap.ShenyuBootstrapApplication`.
 

--- a/versioned_docs/version-2.4.0/deployment/deployment-package.md
+++ b/versioned_docs/version-2.4.0/deployment/deployment-package.md
@@ -22,7 +22,7 @@ This article introduces the deployment of the `Apache ShenYu` gateway using the 
 > linux: ./start.sh --spring.profiles.active = h2
 ```
 
-* use `MySQL` to store data, go to the `/conf` directory, and modify the configuration of `mysql` in `application.yaml`.
+* use `MySQL` to store data, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to /$(your_work_dir)/ext-lib, go to the `/conf` directory, and modify the configuration of `mysql` in `application.yaml`.
 
 ```
 > windows: start.bat 

--- a/versioned_docs/version-2.4.1/deployment/deployment-docker.md
+++ b/versioned_docs/version-2.4.1/deployment/deployment-docker.md
@@ -20,7 +20,7 @@ This article introduces the use of `docker` to deploy the `Apache ShenYu` gatewa
 > docker run -d -p 9095:9095 --net shenyu apache/shenyu-admin:2.4.1
 ```
 
-* use `MySQL` to store data, copy `mysql-connector.jar` to `/$(your_work_dir)/ext-lib`：
+* use `MySQL` to store data, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to `/$(your_work_dir)/ext-lib`：
 
 ```
 docker run -v /${your_work_dir}/ext-lib:/opt/shenyu-admin/ext-lib -e "SPRING_PROFILES_ACTIVE=mysql" -e "spring.datasource.url=jdbc:mysql://${your_ip_port}/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false" -e "spring.datasource.username=${your_username}" -e "spring.datasource.password=${your_password}" -d -p 9095:9095 --net shenyu apache/shenyu-admin:2.4.1

--- a/versioned_docs/version-2.4.1/deployment/deployment-k8s.md
+++ b/versioned_docs/version-2.4.1/deployment/deployment-k8s.md
@@ -19,7 +19,7 @@ This article introduces the use of `k8s` to deploy the `Apache ShenYu` gateway.
 >
 > Similar to the h2 process, there are two points to note
 >
-> 1. you need to load mysql-connector.jar, so you need a place to store the file
+> 1. you need to load [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar), so you need a place to store the file
 > 2. you need to specify an external mysql database configuration to proxy the external mysql database via endpoint
 >
 > The process is as follows.

--- a/versioned_docs/version-2.4.1/deployment/deployment-local.md
+++ b/versioned_docs/version-2.4.1/deployment/deployment-local.md
@@ -28,8 +28,8 @@ This article introduces how to start the `Apache ShenYu` gateway in the local en
 
   * If you use `h2` to store, set the variable `--spring.profiles.active = h2`.
 
-  * If you use `MySQL` for storage, modify the `mysql` configuration in `application.yaml`.
-    
+  * If you use `MySQL` for storage, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to /$(your_work_dir)/ext-lib, and modify the `mysql` configuration in `application.yaml`.
+  
   * If you use `PostgreSql` for storage, modify the `pg` of `spring.profiles.active` configuration in `application.yaml`.
 
 * use the development tool to start `org.apache.shenyu.bootstrap.ShenyuBootstrapApplication`.

--- a/versioned_docs/version-2.4.1/deployment/deployment-package.md
+++ b/versioned_docs/version-2.4.1/deployment/deployment-package.md
@@ -22,7 +22,7 @@ This article introduces the deployment of the `Apache ShenYu` gateway using the 
 > linux: ./start.sh --spring.profiles.active = h2
 ```
 
-* use `MySQL` to store data, go to the `/conf` directory, and modify the configuration of `mysql` in `application.yaml`.
+* use `MySQL` to store data, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to /$(your_work_dir)/ext-lib, go to the `/conf` directory, and modify the configuration of `mysql` in `application.yaml`.
 
 ```
 > windows: start.bat 

--- a/versioned_docs/version-2.4.2/deployment/deployment-docker.md
+++ b/versioned_docs/version-2.4.2/deployment/deployment-docker.md
@@ -20,7 +20,7 @@ This article introduces the use of `docker` to deploy the `Apache ShenYu` gatewa
 > docker run -d -p 9095:9095 --net shenyu apache/shenyu-admin:2.4.2
 ```
 
-* use `MySQL` to store data, copy `mysql-connector.jar` to `/$(your_work_dir)/ext-lib`：
+* use `MySQL` to store data, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to `/$(your_work_dir)/ext-lib`：
 
 ```
 docker run -v /${your_work_dir}/ext-lib:/opt/shenyu-admin/ext-lib -e "SPRING_PROFILES_ACTIVE=mysql" -e "spring.datasource.url=jdbc:mysql://${your_ip_port}/shenyu?useUnicode=true&characterEncoding=utf-8&useSSL=false" -e "spring.datasource.username=${your_username}" -e "spring.datasource.password=${your_password}" -d -p 9095:9095 --net shenyu apache/shenyu-admin:2.4.2

--- a/versioned_docs/version-2.4.2/deployment/deployment-k8s.md
+++ b/versioned_docs/version-2.4.2/deployment/deployment-k8s.md
@@ -19,7 +19,7 @@ This article introduces the use of `k8s` to deploy the `Apache ShenYu` gateway.
 >
 > Similar to the h2 process, there are two points to note
 >
-> 1. you need to load mysql-connector.jar, so you need a place to store the file
+> 1. you need to load [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar), so you need a place to store the file
 > 2. you need to specify an external mysql database configuration to proxy the external mysql database via endpoint
 >
 > The process is as follows.

--- a/versioned_docs/version-2.4.2/deployment/deployment-local.md
+++ b/versioned_docs/version-2.4.2/deployment/deployment-local.md
@@ -28,7 +28,7 @@ This article introduces how to start the `Apache ShenYu` gateway in the local en
 
   * If you use `h2` to store, set the variable `--spring.profiles.active = h2`.
 
-  * If you use `MySQL` for storage, modify the `mysql` configuration in `application.yaml`.
+  * If you use `MySQL` for storage, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to /$(your_work_dir)/ext-lib, and modify the `mysql` configuration in `application.yaml`.
   
   * If you use `PostgreSql` for storage, modify the `pg` of `spring.profiles.active` configuration in `application.yaml`.
 

--- a/versioned_docs/version-2.4.2/deployment/deployment-package.md
+++ b/versioned_docs/version-2.4.2/deployment/deployment-package.md
@@ -22,7 +22,7 @@ This article introduces the deployment of the `Apache ShenYu` gateway using the 
 > linux: ./start.sh --spring.profiles.active = h2
 ```
 
-* use `MySQL` to store data, go to the `/conf` directory, and modify the configuration of `mysql` in `application.yaml`.
+* use `MySQL` to store data, copy [mysql-connector.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18.jar) to /$(your_work_dir)/ext-lib, go to the `/conf` directory, and modify the configuration of `mysql` in `application.yaml`.
 
 ```
 > windows: start.bat 


### PR DESCRIPTION
Fixes #449 
In the deployment document, the description of using Mysql to store data lack of 'mysql-connector.jar' . the jar file needs to be downloaded separately.


