### PR TITLE
Update pdf links in download & zh/download

### DIFF
--- a/.github/scripts/generate-pdf.py
+++ b/.github/scripts/generate-pdf.py
@@ -147,46 +147,6 @@ class Folder(Document):
             ] + docs_name)
 
 
-class TopDocument:
-    def __init__(self, path: str) -> None:
-        self.path = path
-        self.sections: List[Document] = []
-        self.documents: List[str] = []
-
-        files_name: List[str] = os.listdir(self.path)
-        files_full_name = [os.path.join(self.path, file_name) for file_name in files_name]
-        for full_name in files_full_name:
-            if os.path.isdir(full_name):
-                section = Folder(full_name)
-                self.sections.append(section)
-        
-
-class DocGenerator:
-    """
-    DocGenerator consists of several tools about document generation.
-    """
-
-    @classmethod
-    def getDocStructure(cls, root_path: str) -> Document:
-        """
-        Now document complies with a rule:
-            docs/
-                - chapter1/_category_.json
-                    - section1/_category_.json
-                        - md files
-                    - md files
-                - chapter2/_category_.json
-                    - md files
-        document is identical to Document
-        Dict: str(file name) -> TextIOWrapper(file descriptor)
-        """
-        os.walk()
-
-    @classmethod
-    def createFileIndexRst(cls, fin: TextIOWrapper):
-        fin.name
-
-
 doc = Folder("docs")
 print(json.dumps(doc.dumps(), indent=2))
 doc.writeIndexRst()

--- a/i18n/zh/docusaurus-plugin-content-pages/download.md
+++ b/i18n/zh/docusaurus-plugin-content-pages/download.md
@@ -69,6 +69,6 @@ pgp apache-shenyu-********.asc
 
 `Apache ShenYu` 提供了打包下载的文档 `PDF` ，供使用者、开发者查阅。
 
-* [中文](/pdf/apache_shenyu_docs_zh.pdf)
+* [中文](https://shenyu.apache.org/pdf/apache_shenyu_docs_zh.pdf)
 
-* [English](/pdf/apache_shenyu_docs_en.pdf)
+* [English](https://shenyu.apache.org/pdf/apache_shenyu_docs_en.pdf)

--- a/src/pages/download.md
+++ b/src/pages/download.md
@@ -69,5 +69,5 @@ pgp apache-shenyu-********.asc
 
 `Apache ShenYu (incubating)` provides a packaged and downloaded `PDF` of the docs for users and developers to use.
 
-* [English](/pdf/apache_shenyu_docs_en.pdf)
+* [English](https://shenyu.apache.org/pdf/apache_shenyu_docs_en.pdf)
 


### PR DESCRIPTION
* change /pdf/apache_shenyu_docs_zh.pdf to https://shenyu.apache.org/pdf/apache_shenyu_docs_zh.pdf
* change /pdf/apache_shenyu_docs_en.pdf to https://shenyu.apache.org/pdf/apache_shenyu_docs_en.pdf
* remove unnecessary code in .github/scripts/generate-pdf.py